### PR TITLE
Fix: Player state cleanup on leave, YAML config formatting, and spawn yaw/pitch

### DIFF
--- a/bukkit/src/BukkitEntity.kt
+++ b/bukkit/src/BukkitEntity.kt
@@ -48,7 +48,7 @@ open class BukkitEntity(val plugin: KhsPlugin, private val inner: org.bukkit.ent
 
     override fun getLocation(): Location {
         val loc = inner.location
-        return Location(loc.x, loc.y, loc.z, inner.world.name)
+        return Location(loc.x, loc.y, loc.z, inner.world.name, loc.yaw, loc.pitch)
     }
 
     override fun getPitch(): Float {
@@ -80,7 +80,7 @@ open class BukkitEntity(val plugin: KhsPlugin, private val inner: org.bukkit.ent
         val world = loader.load() ?: return
         val bukkitWorld = (world as? BukkitWorld)?.inner ?: return
 
-        inner.teleport(org.bukkit.Location(bukkitWorld, location.x, location.y, location.z))
+        inner.teleport(org.bukkit.Location(bukkitWorld, location.x, location.y, location.z, location.yaw, location.pitch))
     }
 
     private fun getCollidesTeam(): Team? {

--- a/bukkit/src/BukkitPlayer.kt
+++ b/bukkit/src/BukkitPlayer.kt
@@ -137,7 +137,7 @@ class BukkitPlayer(plugin: KhsPlugin, val inner: org.bukkit.entity.Player) :
 
     override fun getEyePosition(): Location {
         val loc = inner.eyeLocation
-        return Location(loc.x, loc.y, loc.z, inner.world.name)
+        return Location(loc.x, loc.y, loc.z, inner.world.name, loc.yaw, loc.pitch)
     }
 
     override fun getEyeDirection(): Vector {

--- a/bukkit/src/BukkitWorld.kt
+++ b/bukkit/src/BukkitWorld.kt
@@ -152,7 +152,7 @@ class BukkitWorld(val shim: BukkitKhsShim, val inner: org.bukkit.World) : Abstra
 
     override fun getSpawn(): Location {
         val loc = inner.spawnLocation
-        return Location(loc.x, loc.y, loc.z, name)
+        return Location(loc.x, loc.y, loc.z, name, loc.yaw, loc.pitch)
     }
 
     @Suppress("UnstableApiUsage")

--- a/core/src/config/util/Serialize.kt
+++ b/core/src/config/util/Serialize.kt
@@ -17,13 +17,12 @@ import kotlin.text.buildString
 fun typeInline(value: Any?): Boolean {
     if (value == null) return true
 
-    return when (value) {
-        is List<*> -> value.all { typeInline(it) }
-        is Map<*, *> -> value.isEmpty()
-        is Boolean -> true
-        value::class.isData -> false
-        else -> true
-    }
+    if (value is List<*>) return value.all { typeInline(it) }
+    if (value is Map<*, *>) return value.isEmpty()
+    if (value is Boolean) return true
+    if (value::class.isData) return false
+
+    return true
 }
 
 fun serializeSection(section: Section): String {

--- a/core/src/game/Game.kt
+++ b/core/src/game/Game.kt
@@ -353,12 +353,16 @@ class Game(val plugin: Khs) {
     }
 
     fun leave(uuid: UUID) {
-        val player = plugin.shim.getPlayer(uuid) ?: return
-
         synchronized(lock) {
             if (!teams.contains(uuid)) return
+            if (teams.isHider(uuid)) hiderLeft = true
             teams.remove(uuid)
         }
+
+        val savedInv = savedInventories.remove(uuid)
+        val savedBoard = savedScoreBoards.remove(uuid)
+
+        val player = plugin.shim.getPlayer(uuid) ?: return
 
         resetPlayer(player)
 
@@ -371,14 +375,14 @@ class Game(val plugin: Khs) {
         // restore inventory
 
         if (plugin.config.saveInventory) {
-            savedInventories[uuid]?.let { player.getInventory().setContents(it) }
+            savedInv?.let { player.getInventory().setContents(it) }
         }
 
         // reset score board
 
         val board =
             if (plugin.config.saveScoreBoard) {
-                savedScoreBoards[uuid]
+                savedBoard
             } else {
                 null
             }

--- a/core/src/world/Location.kt
+++ b/core/src/world/Location.kt
@@ -5,6 +5,8 @@ data class Location(
     var y: Double = 0.0,
     var z: Double = 0.0,
     var worldName: String = "world",
+    var yaw: Float = 0f,
+    var pitch: Float = 0f,
 ) {
     /**
      * @return the distance between the two locations, returning null of they are in difference
@@ -17,10 +19,10 @@ data class Location(
 
     /** Convert to a [Position] */
     fun toPosition(): Position {
-        return Position(x, y, z)
+        return Position(x, y, z, yaw, pitch)
     }
 
     fun clone(): Location {
-        return Location(x, y, z, worldName)
+        return Location(x, y, z, worldName, yaw, pitch)
     }
 }

--- a/core/src/world/Position.kt
+++ b/core/src/world/Position.kt
@@ -5,7 +5,7 @@ import cat.freya.khs.math.Vector
 import kotlin.math.pow
 import kotlin.math.sqrt
 
-data class Position(var x: Double = 0.0, var y: Double = 0.0, var z: Double = 0.0) {
+data class Position(var x: Double = 0.0, var y: Double = 0.0, var z: Double = 0.0, var yaw: Float = 0f, var pitch: Float = 0f) {
     /** @return the 3d distance between this and other */
     fun distance(other: Position): Double {
         val dx = this.x - other.x
@@ -17,7 +17,7 @@ data class Position(var x: Double = 0.0, var y: Double = 0.0, var z: Double = 0.
 
     /** Convert to a [Location] given a world name */
     fun toLocation(worldName: String): Location {
-        return Location(this.x, this.y, this.z, worldName)
+        return Location(this.x, this.y, this.z, worldName, this.yaw, this.pitch)
     }
 
     /** Convert to a [LegacyPosition] used for deprecated config values */
@@ -30,6 +30,6 @@ data class Position(var x: Double = 0.0, var y: Double = 0.0, var z: Double = 0.
     }
 
     fun clone(): Position {
-        return Position(x, y, z)
+        return Position(x, y, z, yaw, pitch)
     }
 }

--- a/mod/src/ModEntity.kt
+++ b/mod/src/ModEntity.kt
@@ -28,7 +28,7 @@ open class ModEntity(val mod: KhsMod, private val inner: net.minecraft.world.ent
 
     override fun getLocation(): Location {
         val worldName = getWorld().name
-        return Location(inner.x, inner.y, inner.z, worldName)
+        return Location(inner.x, inner.y, inner.z, worldName, inner.yRot, inner.xRot)
     }
 
     override fun getPitch(): Float {
@@ -59,8 +59,8 @@ open class ModEntity(val mod: KhsMod, private val inner: net.minecraft.world.ent
         val loader = mod.shim.getWorldLoader(location.worldName)
         val world = loader.load() ?: return
 
-        val relative = Relative.union(Relative.DELTA, Relative.ROTATION)
-        inner.teleportTo(world.inner, location.x, location.y, location.z, relative, 0f, 0f, false)
+        val relative = Relative.DELTA
+        inner.teleportTo(world.inner, location.x, location.y, location.z, relative, location.yaw, location.pitch, false)
     }
 
     private fun getCollidesTeam(): PlayerTeam {

--- a/mod/src/ModPlayer.kt
+++ b/mod/src/ModPlayer.kt
@@ -156,7 +156,7 @@ class ModPlayer(mod: KhsMod, val inner: ServerPlayer) :
 
     override fun getEyePosition(): Location {
         val v = inner.eyePosition
-        return Location(v.x, v.y, v.z, getWorld().name)
+        return Location(v.x, v.y, v.z, getWorld().name, inner.yRot, inner.xRot)
     }
 
     override fun getEyeDirection(): Vector {

--- a/mod/src/ModWorld.kt
+++ b/mod/src/ModWorld.kt
@@ -153,7 +153,7 @@ class ModWorld(val mod: KhsMod, val inner: ServerLevel) : AbstractWorld(mod.shim
 
     override fun getSpawn(): Location {
         val pos = inner.respawnData.pos()
-        return Location(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble(), name)
+        return Location(pos.x.toDouble(), pos.y.toDouble(), pos.z.toDouble(), name, 0f, 0f)
     }
 
     override fun playSound(position: Position, sound: String, volume: Double, pitch: Double) {


### PR DESCRIPTION
## Description of Changes

1. **Fixed players retaining roles after leaving a game:**
    - Moved team removal logic before the `getPlayer(uuid)` check in `leave()`. This ensures offline players are actually removed from teams. Also added the missing `hiderLeft = true` trigger.
2. **Cleared saved inventories of offline players to prevent memory leaks:**
    - Saved inventories and scoreboards are now unconditionally removed from `savedInventories` and `savedScoreBoards` when a player leaves.
3. **Added yaw and pitch to Position and Location:**
   - `getLocation()` and `teleport()` now respect player rotation. Commands like `/hs setexit` will now correctly save and load facing directions.
 4. **Fixed YAML config formatting for data classes in items.yml:**
    - Fixed a logic bug in `Serialize.kt`'s `typeInline()`. Data classes now format correctly as YAML lists (with `-`) instead of inline arrays `[]`.

## Testing

- Tested on software
  - [ ] Bukkit
  - [ ] Spigot
  - [x] Paper
- Tested on mc versions
  - [ ] 1.8.x
  - [ ] 1.9.x
  - [ ] 1.10.x-1.12.x
  - [ ] 1.13.x-1.20.x
  - [x] 1.21.x