### PR TITLE
Feature: Configurable item slots, block protection & new placeholders

### DIFF
--- a/.wiki/6-Placeholders.md
+++ b/.wiki/6-Placeholders.md
@@ -4,6 +4,15 @@ This plugin supports software such as [PlaceholderAPI](https://placeholderapi.co
 
 A placeholder is a string such as `%hs_team%`, which in this case returns what team you are on
 
+#### Game Information
+
+The following placeholders can be used to get information about the current state of the game lobby:
+- `%hs_status%` - Returns the current status of the game (Waiting, Starting, In-game, Ending).
+- `%hs_players%` - Returns the total number of players currently in the lobby/game.
+- `%hs_minplayers%` - Returns the minimum number of players required to start the countdown.
+- `%hs_maxplayers%` - Returns the maximum number of players allowed in the lobby.
+- `%hs_map%` - Returns the name of the current map.
+
 #### Teams
 
 The following teams: `hiders`, `seekers`, and `spectators` can be used in `%hs_<team>%` to get

--- a/bukkit/src/event/BreakListener.kt
+++ b/bukkit/src/event/BreakListener.kt
@@ -8,12 +8,21 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.EntityBreakDoorEvent
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
 
 class BreakListener(val plugin: KhsPlugin) : Listener {
     init {
         plugin.server.pluginManager.registerEvents(this, plugin)
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onBlockPlace(event: BlockPlaceEvent) {
+        val game = plugin.khs.game
+        if (game.teams.contains(event.player.uniqueId)) {
+            event.isCancelled = true
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)

--- a/core/src/Placeholder.kt
+++ b/core/src/Placeholder.kt
@@ -1,6 +1,7 @@
 package cat.freya.khs
 
 import cat.freya.khs.db.PlayerStat
+import cat.freya.khs.game.Game
 import java.util.UUID
 import kotlin.text.toULong
 
@@ -59,6 +60,31 @@ private fun handlePlayerStat(req: PlaceholderRequest): String {
 fun handlePlaceholder(req: PlaceholderRequest): String {
     val arg0 = req.arg0 ?: return req.invalid
     return when (arg0) {
+        "status" -> {
+            val game = req.plugin.game
+            when (game.status) {
+                Game.Status.LOBBY -> if (game.timer != null) "Starting" else "Waiting"
+                Game.Status.HIDING, Game.Status.SEEKING -> "In-game"
+                Game.Status.FINISHED -> "Ending"
+            }
+        }
+
+        "minplayers" -> {
+            req.plugin.config.lobby.min
+                .toString()
+        }
+
+        "maxplayers" -> {
+            req.plugin.config.lobby.max
+                .toString()
+        }
+
+        "players" -> {
+            req.plugin.game.teams
+                .size()
+                .toString()
+        }
+
         // game info
         "hiders" -> {
             req.plugin.game.teams

--- a/core/src/config/Config.kt
+++ b/core/src/config/Config.kt
@@ -66,6 +66,7 @@ data class ItemConfig(
     @Omittable var unbreakable: Boolean? = null,
     @Omittable var modelData: UInt? = null,
     @Omittable var owner: String? = null,
+    @Omittable var slot: UInt? = null,
 )
 
 data class EffectConfig(
@@ -115,9 +116,10 @@ data class LobbyConfig(
             name = "&c Leave Lobby",
             material = "BED",
             lore = listOf("Go back to server hub"),
+            slot = 0u,
         ),
     @Comment("Item for admins to use to force start the game")
-    var startItem: ItemConfig = ItemConfig(name = "&bStart Game", material = "CLOCK"),
+    var startItem: ItemConfig = ItemConfig(name = "&bStart Game", material = "CLOCK", slot = 8u),
 )
 
 data class SpectatorItemsConfig(
@@ -127,6 +129,7 @@ data class SpectatorItemsConfig(
             name = "&bToggle Flight",
             material = "FEATHER",
             lore = listOf("Turns flying on and off"),
+            slot = 6u,
         ),
     /** Item for spectators to teleport to other players */
     var teleport: ItemConfig =
@@ -134,6 +137,7 @@ data class SpectatorItemsConfig(
             name = "&bTeleport to Others",
             material = "COMPASS",
             lore = listOf("Allows you to teleport to all other players in game"),
+            slot = 3u,
         ),
 )
 
@@ -271,4 +275,11 @@ data class KhsConfig(
     @Section("Auto Generated")
     @Comment("Location where players are teleported to when they run (/hs leave).")
     var exit: Location? = null,
-)
+) {
+    fun migrate() {
+        if (lobby.leaveItem.slot == null) lobby.leaveItem.slot = 0u
+        if (lobby.startItem.slot == null) lobby.startItem.slot = 8u
+        if (spectatorItems.flight.slot == null) spectatorItems.flight.slot = 6u
+        if (spectatorItems.teleport.slot == null) spectatorItems.teleport.slot = 3u
+    }
+}

--- a/core/src/config/Items.kt
+++ b/core/src/config/Items.kt
@@ -99,4 +99,18 @@ data class KhsItemsConfig(
                 particles = false,
             ),
         ),
-)
+) {
+    fun migrate() {
+        var nextHiderSlot = 0u
+        for (item in hiderItems) {
+            if (item.slot == null) item.slot = nextHiderSlot
+            nextHiderSlot = maxOf(nextHiderSlot, item.slot!!) + 1u
+        }
+
+        var nextSeekerSlot = 0u
+        for (item in seekerItems) {
+            if (item.slot == null) item.slot = nextSeekerSlot
+            nextSeekerSlot = maxOf(nextSeekerSlot, item.slot!!) + 1u
+        }
+    }
+}

--- a/core/src/config/Items.kt
+++ b/core/src/config/Items.kt
@@ -103,14 +103,16 @@ data class KhsItemsConfig(
     fun migrate() {
         var nextHiderSlot = 0u
         for (item in hiderItems) {
-            if (item.slot == null) item.slot = nextHiderSlot
-            nextHiderSlot = maxOf(nextHiderSlot, item.slot!!) + 1u
+            val currentSlot = item.slot ?: nextHiderSlot
+            item.slot = currentSlot
+            nextHiderSlot = maxOf(nextHiderSlot, currentSlot) + 1u
         }
 
         var nextSeekerSlot = 0u
         for (item in seekerItems) {
-            if (item.slot == null) item.slot = nextSeekerSlot
-            nextSeekerSlot = maxOf(nextSeekerSlot, item.slot!!) + 1u
+            val currentSlot = item.slot ?: nextSeekerSlot
+            item.slot = currentSlot
+            nextSeekerSlot = maxOf(nextSeekerSlot, currentSlot) + 1u
         }
     }
 }

--- a/core/src/game/Game.kt
+++ b/core/src/game/Game.kt
@@ -780,16 +780,23 @@ class Game(val plugin: Khs) {
 
     fun giveHiderItems(hider: Player) {
         val inventory = hider.getInventory()
-        val items = plugin.itemsConfig.hiderItems.mapNotNull { plugin.parseItem(it) }
         val effects = plugin.itemsConfig.hiderEffects.mapNotNull { plugin.parseEffect(it) }
 
         inventory.clearAll()
-        items.withIndex().forEach { (i, item) -> inventory.set(i.toUInt(), item) }
+
+        var nextSlot = 0u
+        for (itemConfig in plugin.itemsConfig.hiderItems) {
+            val item = plugin.parseItem(itemConfig) ?: continue
+            val slot = itemConfig.slot ?: nextSlot
+            inventory.set(slot, item)
+            nextSlot = maxOf(nextSlot, slot) + 1u
+        }
 
         // glow power-up
         if (!plugin.config.alwaysGlow && plugin.config.glow.enabled) {
             val item = plugin.parseItem(plugin.config.glow.item)
-            item?.let { hider.getInventory().set(items.size.toUInt(), it) }
+            val slot = plugin.config.glow.item.slot ?: nextSlot
+            item?.let { hider.getInventory().set(slot, it) }
         }
 
         val helmet = plugin.parseItem(plugin.itemsConfig.hiderHelmet)
@@ -814,11 +821,17 @@ class Game(val plugin: Khs) {
 
     fun giveSeekerItems(seeker: Player) {
         val inventory = seeker.getInventory()
-        val items = plugin.itemsConfig.seekerItems.mapNotNull { plugin.parseItem(it) }
         val effects = plugin.itemsConfig.seekerEffects.mapNotNull { plugin.parseEffect(it) }
 
         inventory.clearAll()
-        items.withIndex().forEach { (i, item) -> inventory.set(i.toUInt(), item) }
+
+        var nextSlot = 0u
+        for (itemConfig in plugin.itemsConfig.seekerItems) {
+            val item = plugin.parseItem(itemConfig) ?: continue
+            val slot = itemConfig.slot ?: nextSlot
+            inventory.set(slot, item)
+            nextSlot = maxOf(nextSlot, slot) + 1u
+        }
 
         val helmet = plugin.parseItem(plugin.itemsConfig.seekerHelmet)
         val chestplate = plugin.parseItem(plugin.itemsConfig.seekerChestplate)
@@ -844,8 +857,8 @@ class Game(val plugin: Khs) {
         val teleportItem = plugin.parseItem(plugin.config.spectatorItems.teleport)
         val flightItem = plugin.parseItem(plugin.config.spectatorItems.flight)
 
-        inventory.set(3u, teleportItem)
-        inventory.set(6u, flightItem)
+        inventory.set(plugin.config.spectatorItems.teleport.slot ?: 3u, teleportItem)
+        inventory.set(plugin.config.spectatorItems.flight.slot ?: 6u, flightItem)
 
         setPlayerHidden(spectator, true)
     }
@@ -858,9 +871,9 @@ class Game(val plugin: Khs) {
         val leaveItem = plugin.parseItem(plugin.config.lobby.leaveItem)
         val startItem = plugin.parseItem(plugin.config.lobby.startItem)
 
-        inventory.set(0u, leaveItem)
+        inventory.set(plugin.config.lobby.leaveItem.slot ?: 0u, leaveItem)
         if (player.hasPermission("hs.start")) {
-            inventory.set(8u, startItem)
+            inventory.set(plugin.config.lobby.startItem.slot ?: 8u, startItem)
         }
     }
 }


### PR DESCRIPTION
### Description of Changes

1. **Configurable item slots:** 
    - Added an optional `slot` property to `ItemConfig`. Items in the lobby, spectator mode, and game loadouts can now be pinned to specific inventory slots.
2. **Config migration:** 
    - Added `migrate()` logic so existing `config.yml` and `items.yml` files automatically get the new slot default values without breaking.
3. **Block place protection:** 
    - Cancelled `BlockPlaceEvent` in `BreakListener` so players in the game can no longer place blocks.  *(I know it's unlikely that someone would place a block, but if an item (for example seeker's sword) is set as a block, it can be placed.)*
4. **New Placeholders:** 
    - Added `%hs_status%`, `%hs_minplayers%`, `%hs_maxplayers%`, and `%hs_players%` to PlaceholderAPI. (Check out: [Added new PlaceholderAPI placeholders](https://github.com/kenshineto/kenshinshideandseek2/commit/2bb7f85b0299e6678f1bb39c383c8f2380b9ac7a))
5. **Wiki update:** 
    - Updated 6-Placeholders.md to include the new placeholders and the previously missing %hs_map%. *(Feel free to revise)*

### Testing

- Tested on software
  - [ ] Bukkit
  - [ ] Spigot
  - [x] Paper
- Tested on mc versions
  - [ ] 1.8.x
  - [ ] 1.9.x
  - [ ] 1.10.x-1.12.x
  - [ ] 1.13.x-1.20.x
  - [x] 1.21.x

---
**P.S.:** By the way, is it possible to rewrite the plugin for a multi-arena system? I know it wouldn't be an easy job as the whole plugin is set up for one game at a time, but it would make it so much better.