### PR TITLE
Feature: Cancel block placement for players

### DIFF
--- a/bukkit/src/event/BreakListener.kt
+++ b/bukkit/src/event/BreakListener.kt
@@ -3,17 +3,32 @@ package cat.freya.khs.bukkit.event
 import cat.freya.khs.bukkit.BukkitPlayer
 import cat.freya.khs.bukkit.KhsPlugin
 import cat.freya.khs.event.BreakEvent
+import cat.freya.khs.event.PlaceEvent
 import cat.freya.khs.event.onBreak
+import cat.freya.khs.event.onPlace
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.EntityBreakDoorEvent
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
 
 class BreakListener(val plugin: KhsPlugin) : Listener {
     init {
         plugin.server.pluginManager.registerEvents(this, plugin)
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onBlockPlace(event: BlockPlaceEvent) {
+        val bukkitPlayer = event.player
+        val block = event.block.type.name
+
+        val khsPlayer = BukkitPlayer(plugin, bukkitPlayer)
+        val khsEvent = PlaceEvent(plugin.khs, khsPlayer, block)
+        onPlace(khsEvent)
+
+        if (khsEvent.cancelled) event.isCancelled = true
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)

--- a/core/src/event/onPlace.kt
+++ b/core/src/event/onPlace.kt
@@ -1,0 +1,15 @@
+package cat.freya.khs.event
+
+import cat.freya.khs.Khs
+import cat.freya.khs.world.Player
+
+data class PlaceEvent(val plugin: Khs, val player: Player, val material: String) : Event()
+
+fun onPlace(event: PlaceEvent) {
+    val (plugin, player, _) = event
+    val game = plugin.game
+
+    if (!game.teams.contains(player.uuid)) return
+
+    event.cancel()
+}


### PR DESCRIPTION
### Description of Changes

**Block place protection:** 
- Cancelled `BlockPlaceEvent` in `BreakListener` so players in the game can no longer place blocks.

### Testing

- Tested on software
  - [ ] Bukkit
  - [ ] Spigot
  - [x] Paper
- Tested on mc versions
  - [ ] 1.8.x
  - [ ] 1.9.x
  - [ ] 1.10.x-1.12.x
  - [ ] 1.13.x-1.20.x
  - [x] 1.21.x
